### PR TITLE
Refactor Styles to use CSS and make it not look bad

### DIFF
--- a/src/vegarando.js
+++ b/src/vegarando.js
@@ -29,8 +29,13 @@ function prepareStyle() {
     const styleTag = document.createElement("style");
 
     styleTag.innerText = `
-     .is-vegetarian {
-        background-color: green;
+     .is-vegetarian .meal {
+        box-shadow: inset 0.5rem 0px 0px 0px #7bc043;
+        transition: all 0.5s;
+     }
+     .is-vegetarian .meal:hover {
+        box-shadow: inset 2rem 0px 0px 0px #7bc043;
+        padding-left: 2rem;
      }
     `;
 

--- a/src/vegarando.js
+++ b/src/vegarando.js
@@ -25,6 +25,18 @@ function hasVeggieOption(elem) {
     return false;
 }
 
+function prepareStyle() {
+    const styleTag = document.createElement("style");
+
+    styleTag.innerText = `
+     .is-vegetarian {
+        background-color: green;
+     }
+    `;
+
+    document.head.appendChild(styleTag);
+}
+
 function tagMeals() {
     for (let c of document.getElementsByClassName("meal-container")) {
         let mealName = c.getElementsByClassName("meal-name")[0]
@@ -44,12 +56,13 @@ function tagMeals() {
             continue;
         }
 
-        c.style.backgroundColor = "green";
+        c.classList.add("is-vegetarian");
     }
 }
 
 // firefox at least silently failed on addon errors, so we have to explicitly catch q.q
 try {
+    prepareStyle();
     tagMeals();
 } catch (error) {
     console.error(error)


### PR DESCRIPTION
This PR will make the extension create a new `style`-Tag in Head and use CSS-Classes for styling. This will make further development easier. While doing so I've also changed the way entries are marked and have included a reveal on hover that can potentially contain other information in the future such as the distinction between vegan and vegetarian.

![grafik](https://user-images.githubusercontent.com/9036001/99966805-26d90300-2d97-11eb-88f6-341eb19c8237.png)
