### PR TITLE
Behebt Fehler der Textunterstreichung

### DIFF
--- a/src/vegarando.js
+++ b/src/vegarando.js
@@ -33,7 +33,8 @@ function highlight(elem, good, text) {
     findAndReplaceDOMText(elem, {
         find: reg,
         wrap: "span",
-        wrapClass: `highlight-${good ? "good" : "bad"}`
+        wrapClass: `highlight-${good ? "good" : "bad"}`,
+        forceContext: true
     })
 }
 


### PR DESCRIPTION
Da bisher das Matching von Wörtern über HTML-Elemente hinweg stattgefunden hat, führte dies zu falschen Unterstreichungen.
War beispielsweise das letzte Wort der Beschreibung ein "Bad" oder "Good" Wort (z.B. Salami), wurde auch das darauffolgende "Wahl" von "Wahl aus:" unterstrichen. Elementgrenzen wurden nicht beachtet und intern das Wort als "SalamiWahl" verarbeitet.

Beispiel: https://www.lieferando.de/speisekarte/rocca-pizza-pasta-1
![grafik](https://user-images.githubusercontent.com/10660618/148375912-9f57dc3f-f1a1-4d10-997b-d2976c93d10e.png)

Dieses Problem ist nun behoben.